### PR TITLE
feat: integration tests approval flow

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -75,7 +75,7 @@ export const registerEnvironmentActions = (
   context: vscode.ExtensionContext,
   environmentsTree: vscode.TreeView<Environment>,
   environmentsDataProvider: Env0EnvironmentsProvider,
-  restartLogs: (env: Environment, deploymentId?: string) => any
+  restartLogs: (env: Environment, deploymentId?: string) => unknown
 ) => {
   context.subscriptions.push(
     vscode.commands.registerCommand("env0.openInEnv0", (env) => {

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosError } from "axios";
+import axios from "axios";
 import * as vscode from "vscode";
 import { ENV0_API_URL, ENV0_ENVIRONMENTS_VIEW_ID } from "./common";
 import {
@@ -10,7 +10,7 @@ const env0KeyIdKey = "env0.keyId";
 const env0SecretKey = "env0.secret";
 
 export class AuthService {
-  public onAuth?: () => any = undefined;
+  public onAuth?: () => unknown = undefined;
   constructor(private readonly context: vscode.ExtensionContext) {}
   public registerLoginCommand() {
     const disposable = vscode.commands.registerCommand(
@@ -41,7 +41,10 @@ export class AuthService {
             return null;
           },
         });
+
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         if (await this.validateUserCredentials(keyId!, secret!)) {
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           await this.storeAuthData(keyId!, secret!);
           this.onAuth?.();
           this.onAuth = undefined;
@@ -94,7 +97,8 @@ export class AuthService {
             },
           });
           return true;
-        } catch (e: any | AxiosError) {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } catch (e: any) {
           if (e?.response?.status >= 400 && e?.response?.status < 500) {
             showInvalidCredentialsMessage();
           } else {

--- a/src/env0-environments-provider.ts
+++ b/src/env0-environments-provider.ts
@@ -62,7 +62,7 @@ export class Env0EnvironmentsProvider
     );
   }
 
-  getParent(element: Environment): vscode.ProviderResult<Environment> {
+  getParent(): vscode.ProviderResult<Environment> {
     return null;
   }
 

--- a/src/environment-logs-provider.ts
+++ b/src/environment-logs-provider.ts
@@ -186,7 +186,7 @@ export class EnvironmentLogsProvider {
     stepName: string
   ) {
     let shouldPoll = false;
-    let startTime: number | string;
+    let startTime: number | string | undefined;
 
     do {
       const steps = await apiClient.getDeploymentSteps(
@@ -201,7 +201,7 @@ export class EnvironmentLogsProvider {
         await apiClient.getDeploymentStepLogs(
           deploymentLogId,
           stepName,
-          startTime!,
+          startTime,
           this.abortController
         );
 

--- a/src/test/integration/mocks/git.ts
+++ b/src/test/integration/mocks/git.ts
@@ -26,7 +26,8 @@ export const mockGitRepoAndBranch = (branchName: string, repoUrl: string) => {
   const getExtensionMock = jestMock.spyOn(vscode.extensions, "getExtension");
   getExtensionMock.mockImplementation((arg) => {
     if (arg === "vscode.git") {
-      return { exports: gitExtensionMock } as any;
+      return { exports: gitExtensionMock } as vscode.Extension<unknown>;
     }
+    return {} as vscode.Extension<unknown>;
   });
 };

--- a/src/test/integration/mocks/notification-message.ts
+++ b/src/test/integration/mocks/notification-message.ts
@@ -56,6 +56,7 @@ export const assertWarningMessageDisplayed = async (message: string) => {
  * the clicked button.
  */
 export const simulateInfoMessageMoreInfoButtonClicked = () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   showInformationMessageSpy.mockResolvedValue("More info" as any);
 };
 
@@ -66,6 +67,7 @@ export const simulateInfoMessageMoreInfoButtonClicked = () => {
  * the clicked button.
  */
 export const simulateErrorMessageMoreInfoButtonClicked = () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   showErrorMessageSpy.mockResolvedValue("More info" as any);
 };
 
@@ -76,12 +78,14 @@ export const simulateErrorMessageMoreInfoButtonClicked = () => {
  * the clicked button.
  */
 export const simulateWarningMessageMoreInfoButtonClicked = () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   showWarningMessageSpy.mockResolvedValue("More info" as any);
 };
 
 // since in the tests we don't have a real uri, we need to mock it
 const spyOnParseUri = () => {
   const uriParseSpy = jestMock.spyOn(vscode.Uri, "parse");
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   uriParseSpy.mockImplementation((url) => url as any);
 };
 

--- a/src/test/integration/mocks/server.ts
+++ b/src/test/integration/mocks/server.ts
@@ -47,7 +47,7 @@ export const mockGetEnvironment = (
         assertAuth(credentials, req.headers.get("Authorization"));
       }
       if (
-        new URL(req.url as any).searchParams.get("organizationId") ===
+        new URL(req.url.toString()).searchParams.get("organizationId") ===
         organizationId
       ) {
         return res(ctx.json(environments));
@@ -71,7 +71,7 @@ export const mockGetDeploymentSteps = () => {
 export const mockRedeployApiResponse = (
   envId: string,
   credentials: Credentials,
-  onSuccess?: () => any
+  onSuccess?: () => unknown
 ) => {
   server.use(
     rest.post(
@@ -90,7 +90,7 @@ export const mockRedeployApiResponse = (
 export const mockApproveApiResponse = (
   deploymentId: string,
   credentials: Credentials,
-  onSuccess?: () => any
+  onSuccess?: () => unknown
 ) => {
   server.use(
     rest.put(
@@ -109,7 +109,7 @@ export const mockApproveApiResponse = (
 export const mockCancelApiResponse = (
   deploymentId: string,
   credentials: Credentials,
-  onSuccess?: () => any
+  onSuccess?: () => unknown
 ) => {
   server.use(
     rest.put(

--- a/src/test/integration/mocks/server.ts
+++ b/src/test/integration/mocks/server.ts
@@ -87,6 +87,44 @@ export const mockRedeployApiResponse = (
   );
 };
 
+export const mockApproveApiResponse = (
+  deploymentId: string,
+  credentials: Credentials,
+  onSuccess?: () => any
+) => {
+  server.use(
+    rest.put(
+      `https://${ENV0_API_URL}/environments/deployments/${deploymentId}`,
+      (req, res, ctx) => {
+        if (credentials) {
+          assertAuth(credentials, req.headers.get("Authorization"));
+        }
+        onSuccess?.();
+        return res(ctx.json({}));
+      }
+    )
+  );
+};
+
+export const mockCancelApiResponse = (
+  deploymentId: string,
+  credentials: Credentials,
+  onSuccess?: () => any
+) => {
+  server.use(
+    rest.put(
+      `https://${ENV0_API_URL}/environments/deployments/${deploymentId}/cancel`,
+      (req, res, ctx) => {
+        if (credentials) {
+          assertAuth(credentials, req.headers.get("Authorization"));
+        }
+        onSuccess?.();
+        return res(ctx.json({}));
+      }
+    )
+  );
+};
+
 before(() => {
   server.listen();
 });

--- a/src/test/integration/suite/environment-actions.test.it.ts
+++ b/src/test/integration/suite/environment-actions.test.it.ts
@@ -1,5 +1,4 @@
 import {
-  MessageType,
   getEnvironmentMock,
   getFirstEnvIconPath,
   getFirstEnvStatus,
@@ -38,7 +37,6 @@ import {
   assertWarningMessageDisplayed,
   simulateWarningMessageMoreInfoButtonClicked,
 } from "../mocks/notification-message";
-import { assert } from "console";
 
 const auth = { keyId: "key-id", secret: "key-secret" };
 const orgId = "org-id";

--- a/src/test/integration/suite/environment-actions.test.it.ts
+++ b/src/test/integration/suite/environment-actions.test.it.ts
@@ -11,6 +11,8 @@ import {
   waitFor,
 } from "./test-utils";
 import {
+  mockApproveApiResponse,
+  mockCancelApiResponse,
   mockGetDeploymentSteps,
   mockGetEnvironment,
   mockGetOrganization,
@@ -33,7 +35,10 @@ import {
   resetShowMessageSpies,
   spyOnOpenExternal,
   spyOnShowMessage,
+  assertWarningMessageDisplayed,
+  simulateWarningMessageMoreInfoButtonClicked,
 } from "../mocks/notification-message";
+import { assert } from "console";
 
 const auth = { keyId: "key-id", secret: "key-secret" };
 const orgId = "org-id";
@@ -82,6 +87,7 @@ const mockFailedEnvironment = async (
 
 const activeEnvironmentIconPath = "favicon-16x16.png";
 const inProgressIconPath = "in_progress.png";
+const waitingForUserIconPath = "waiting_for_user.png";
 
 const envName = "my env";
 let environmentMock: EnvironmentModel;
@@ -191,6 +197,97 @@ suite("environment actions", function () {
         inProgressEnvironment.id,
         inProgressEnvironment.projectId
       );
+    });
+  });
+
+  suite("approval flow", () => {
+    test("should show waiting for user status and icon when env waiting for user", async () => {
+      await initTest([environmentMock]);
+      const inProgressEnvironment = await redeploy({
+        environment: environmentMock,
+        auth,
+        orgId,
+      });
+
+      await mockEnvironmentWithUpdatedStatus(
+        inProgressEnvironment,
+        EnvironmentStatus.WAITING_FOR_USER
+      );
+      await waitFor(() =>
+        expect(getFirstEnvIconPath()).toContain(waitingForUserIconPath)
+      );
+      expect(getFirstEnvStatus()).toBe("WAITING_FOR_USER");
+    });
+
+    test("should show waiting for user notification when deployment waiting for user", async () => {
+      await initTest([environmentMock]);
+      const inProgressEnvironment = await redeploy({
+        environment: environmentMock,
+        auth,
+        orgId,
+      });
+      simulateWarningMessageMoreInfoButtonClicked();
+      await mockEnvironmentWithUpdatedStatus(
+        inProgressEnvironment,
+        EnvironmentStatus.WAITING_FOR_USER
+      );
+      await assertWarningMessageDisplayed(
+        `Environment ${envName} is waiting for approval`
+      );
+      assertOpenEnvironmentInBrowserWhenMoreInfoClicked(
+        environmentMock.id,
+        environmentMock.projectId
+      );
+    });
+
+    test("should approve when user approve", async () => {
+      await initTest([environmentMock]);
+      const inProgressEnvironment = await redeploy({
+        environment: environmentMock,
+        auth,
+        orgId,
+      });
+      const waitingForUserEnvironment = await mockEnvironmentWithUpdatedStatus(
+        inProgressEnvironment,
+        EnvironmentStatus.WAITING_FOR_USER
+      );
+      await waitFor(() =>
+        expect(getFirstEnvIconPath()).toContain(waitingForUserIconPath)
+      );
+
+      const onApprove = jestMock.fn();
+      mockApproveApiResponse(
+        waitingForUserEnvironment.latestDeploymentLog.id,
+        auth,
+        onApprove
+      );
+      vscode.commands.executeCommand("env0.approve", getFirstEnvironment());
+      await waitFor(() => expect(onApprove).toHaveBeenCalled());
+    });
+
+    test("should cancel when user cancel", async () => {
+      await initTest([environmentMock]);
+      const inProgressEnvironment = await redeploy({
+        environment: environmentMock,
+        auth,
+        orgId,
+      });
+      const waitingForUserEnvironment = await mockEnvironmentWithUpdatedStatus(
+        inProgressEnvironment,
+        EnvironmentStatus.WAITING_FOR_USER
+      );
+      await waitFor(() =>
+        expect(getFirstEnvIconPath()).toContain(waitingForUserIconPath)
+      );
+
+      const onCancel = jestMock.fn();
+      mockCancelApiResponse(
+        waitingForUserEnvironment.latestDeploymentLog.id,
+        auth,
+        onCancel
+      );
+      vscode.commands.executeCommand("env0.cancel", getFirstEnvironment());
+      await waitFor(() => expect(onCancel).toHaveBeenCalled());
     });
   });
 });

--- a/src/test/integration/suite/test-utils.ts
+++ b/src/test/integration/suite/test-utils.ts
@@ -11,7 +11,7 @@ import * as extension from "../../../../dist/extension.js";
 import { Env0EnvironmentsProvider } from "../../../env0-environments-provider";
 
 export const waitFor = <T>(
-  callback: (...args: any[]) => T,
+  callback: (...args: unknown[]) => T,
   retries = 5
 ): Promise<T> => {
   return retry(callback, { retries, minTimeout: 300, maxTimeout: 1000 });

--- a/src/test/unit/extension.test.ts
+++ b/src/test/unit/extension.test.ts
@@ -23,7 +23,7 @@ describe("extension", () => {
   beforeEach(() => {
     environmentsDataProvider = {
       refresh: jest.fn(),
-    } as any as Env0EnvironmentsProvider;
+    } as unknown as Env0EnvironmentsProvider;
 
     environmentsTree = {} as vscode.TreeView<Environment>;
   });


### PR DESCRIPTION
Integration tests for environment approval flow.

- Ensure that HTTP requests cancel and approve are called with the correct arguments and authentication.
- Verify that pop-up notifications display the appropriate message when the environment status is updated.
- Confirm that the "show more" button in the pop-up notification opens the environment page in the browser.
- Validate that the environment, its icon, and status are updated in line with the environment's status.

For stubs and mocks, I've utilized jest-mock.

Given the limitations where I can't simulate a user click on an environment action, I've opted to execute the command that's triggered when a user clicks on an environment action.
Additionally, since I can't retrieve the value from a VS Code pop-up notification directly, I've employed a spy on the VS Code API responsible for displaying the pop-up notification.