### PR TITLE
feat: environment actions abort and destroy tests

### DIFF
--- a/src/test/integration/mocks/server.ts
+++ b/src/test/integration/mocks/server.ts
@@ -128,7 +128,7 @@ export const mockCancelApiResponse = (
 export const mockAbortApiResponse = (
   deploymentId: string,
   credentials: Credentials,
-  onSuccess?: () => any
+  onSuccess?: () => unknown
 ) => {
   server.use(
     rest.post(
@@ -147,7 +147,7 @@ export const mockAbortApiResponse = (
 export const mockDestroyApiResponse = (
   envId: string,
   credentials: Credentials,
-  onSuccess?: () => any
+  onSuccess?: () => unknown
 ) => {
   server.use(
     rest.post(

--- a/src/test/integration/mocks/server.ts
+++ b/src/test/integration/mocks/server.ts
@@ -87,6 +87,44 @@ export const mockRedeployApiResponse = (
   );
 };
 
+export const mockAbortApiResponse = (
+  deploymentId: string,
+  credentials: Credentials,
+  onSuccess?: () => any
+) => {
+  server.use(
+    rest.post(
+      `https://${ENV0_API_URL}/environments/deployments/${deploymentId}/abort`,
+      (req, res, ctx) => {
+        if (credentials) {
+          assertAuth(credentials, req.headers.get("Authorization"));
+        }
+        onSuccess?.();
+        return res(ctx.json({}));
+      }
+    )
+  );
+};
+
+export const mockDestroyApiResponse = (
+  envId: string,
+  credentials: Credentials,
+  onSuccess?: () => any
+) => {
+  server.use(
+    rest.post(
+      `https://${ENV0_API_URL}/environments/${envId}/destroy`,
+      (req, res, ctx) => {
+        if (credentials) {
+          assertAuth(credentials, req.headers.get("Authorization"));
+        }
+        onSuccess?.();
+        return res(ctx.json({}));
+      }
+    )
+  );
+};
+
 before(() => {
   server.listen();
 });

--- a/src/test/integration/suite/environment-actions.test.it.ts
+++ b/src/test/integration/suite/environment-actions.test.it.ts
@@ -11,6 +11,8 @@ import {
 } from "./test-utils";
 import {
   mockAbortApiResponse,
+  mockApproveApiResponse,
+  mockCancelApiResponse,
   mockDestroyApiResponse,
   mockGetDeploymentSteps,
   mockGetEnvironment,

--- a/src/test/integration/suite/environment-actions.test.it.ts
+++ b/src/test/integration/suite/environment-actions.test.it.ts
@@ -11,6 +11,8 @@ import {
   waitFor,
 } from "./test-utils";
 import {
+  mockAbortApiResponse,
+  mockDestroyApiResponse,
   mockGetDeploymentSteps,
   mockGetEnvironment,
   mockGetOrganization,
@@ -82,6 +84,8 @@ const mockFailedEnvironment = async (
 
 const activeEnvironmentIconPath = "favicon-16x16.png";
 const inProgressIconPath = "in_progress.png";
+const inactiveIconPath = "inactive.png";
+const failedIconPath = "failed.png";
 
 const envName = "my env";
 let environmentMock: EnvironmentModel;
@@ -192,5 +196,61 @@ suite("environment actions", function () {
         inProgressEnvironment.projectId
       );
     });
+  });
+
+  suite("abort", () => {
+    test("should abort when user abort", async () => {
+      await initTest([environmentMock]);
+      const inProgressEnvironment = await redeploy({
+        environment: environmentMock,
+        auth,
+        orgId,
+      });
+
+      const onAbort = jestMock.fn();
+      mockAbortApiResponse(
+        inProgressEnvironment.latestDeploymentLog.id,
+        auth,
+        onAbort
+      );
+      vscode.commands.executeCommand("env0.abort", getFirstEnvironment());
+      await waitFor(() => expect(onAbort).toHaveBeenCalled());
+    });
+
+    test("should update environment status and icon when user abort deployment", async () => {
+      await initTest([environmentMock]);
+      const inProgressEnvironment = await redeploy({
+        environment: environmentMock,
+        auth,
+        orgId,
+      });
+
+      mockAbortApiResponse(inProgressEnvironment.latestDeploymentLog.id, auth);
+      vscode.commands.executeCommand("env0.abort", getFirstEnvironment());
+      const abortingEnvironment = await mockEnvironmentWithUpdatedStatus(
+        inProgressEnvironment,
+        EnvironmentStatus.ABORTING
+      );
+
+      await waitFor(() =>
+        expect(getFirstEnvIconPath()).toContain(inactiveIconPath)
+      );
+      expect(getFirstEnvStatus()).toBe("ABORTING");
+
+      await mockEnvironmentWithUpdatedStatus(
+        abortingEnvironment,
+        EnvironmentStatus.ABORTED
+      );
+      await waitFor(() => expect(getFirstEnvStatus()).toBe("ABORTED"));
+      expect(getFirstEnvIconPath()).toContain(failedIconPath);
+    });
+  });
+
+  test("should destroy when user destroy", async () => {
+    await initTest([environmentMock]);
+    const onDestroy = jestMock.fn();
+    mockDestroyApiResponse(environmentMock.id, auth, onDestroy);
+    vscode.commands.executeCommand("env0.destroy", getFirstEnvironment());
+    await waitFor(() => expect(onDestroy).toHaveBeenCalled());
   });
 });


### PR DESCRIPTION
Integration tests for environment destroy and abort deployment

- Ensure that HTTP requests are called with the correct arguments and authentication.
- Validate that the environment, its icon, and status are updated in line with the environment's status.

 For stubs and mocks, I've utilized jest-mock.

Given the limitations where I can't simulate a user click on an environment action, I've opted to execute the command that's triggered when a user clicks on an environment action.
Additionally, since I can't retrieve the value from a VS Code pop-up notification directly, I've employed a spy on the VS Code API responsible for displaying the pop-up notification.