### PR TITLE
feat: deployment logs integration test

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -91,13 +91,15 @@ export async function activate(context: vscode.ExtensionContext) {
   });
   authService.registerLogoutCommand(onLogOut);
 
-  environmentsTree.onDidChangeSelection(async (e) => {
-    const env = e.selection[0];
+  context.subscriptions.push(
+    environmentsTree.onDidChangeSelection(async (e) => {
+      const env = e.selection[0];
 
-    if (env) {
-      restartLogs(env);
-    }
-  });
+      if (env) {
+        restartLogs(env);
+      }
+    })
+  );
 
   registerEnvironmentActions(
     context,

--- a/src/test/integration/mocks/output-channel.ts
+++ b/src/test/integration/mocks/output-channel.ts
@@ -1,0 +1,23 @@
+import * as vscode from "vscode";
+import { ModuleMocker } from "jest-mock";
+const mock = new ModuleMocker(global);
+
+let logs: string[] = [];
+
+export const getOutputChannelLogs = () => logs;
+export const outputChannelMock = {
+  show: mock.fn(),
+  clear: mock.fn(() => (logs = [])),
+  appendLine: (value: string) => logs.push(value),
+};
+
+export const mockOutputChannel = () => {
+  mock
+    .spyOn(vscode.window, "createOutputChannel")
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .mockImplementation(() => outputChannelMock as any);
+};
+
+export const resetOutputChannelMocks = () => {
+  mock.resetAllMocks();
+};

--- a/src/test/integration/mocks/server.ts
+++ b/src/test/integration/mocks/server.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import assert from "assert";
 import { rest } from "msw";
 import { setupServer } from "msw/node";

--- a/src/test/integration/mocks/server.ts
+++ b/src/test/integration/mocks/server.ts
@@ -90,7 +90,9 @@ export const mockRedeployApiResponse = (
           assertAuth(credentials, req.headers.get("Authorization"));
         }
         onSuccess?.();
-        return res(ctx.json({ id: newDeploymentId || "new-deployment-id" }));
+        return res(
+          ctx.json({ id: newDeploymentId || "redeploy-new-deployment-id" })
+        );
       }
     )
   );

--- a/src/test/integration/mocks/server.ts
+++ b/src/test/integration/mocks/server.ts
@@ -78,7 +78,8 @@ export const mockGetDeploymentStepsApiResponse = (
 export const mockRedeployApiResponse = (
   envId: string,
   credentials: Credentials,
-  onSuccess?: () => unknown
+  onSuccess?: () => unknown,
+  newDeploymentId?: string
 ) => {
   server.use(
     rest.post(
@@ -88,7 +89,7 @@ export const mockRedeployApiResponse = (
           assertAuth(credentials, req.headers.get("Authorization"));
         }
         onSuccess?.();
-        return res(ctx.json({}));
+        return res(ctx.json({ id: newDeploymentId || "new-deployment-id" }));
       }
     )
   );

--- a/src/test/integration/mocks/server.ts
+++ b/src/test/integration/mocks/server.ts
@@ -4,7 +4,12 @@ import { setupServer } from "msw/node";
 import { before, after, afterEach } from "mocha";
 import { ENV0_API_URL } from "../../../common";
 import { EnvironmentModel } from "../../../get-environments";
-import { Credentials } from "../../../types";
+import {
+  Credentials,
+  DeploymentStatus,
+  DeploymentStepLogsResponse,
+  DeploymentStepResponse,
+} from "../../../types";
 
 const server = setupServer(
   rest.all(`*`, (_req, res, ctx) => {
@@ -57,12 +62,14 @@ export const mockGetEnvironment = (
   );
 };
 
-export const mockGetDeploymentSteps = () => {
+export const mockGetDeploymentStepsApiResponse = (
+  steps: DeploymentStepResponse = []
+) => {
   server.use(
     rest.get(
       `https://${ENV0_API_URL}/deployments/:deploymentLogId/steps`,
       (req, res, ctx) => {
-        return res(ctx.json([]));
+        return res(ctx.json(steps));
       }
     )
   );
@@ -123,6 +130,84 @@ export const mockCancelApiResponse = (
       }
     )
   );
+};
+export const mockGetDeploymentApiResponse = (
+  deploymentLogId: string,
+  credentials: Credentials,
+  deployment: { status: string },
+  onSuccess?: () => unknown
+) => {
+  server.use(
+    rest.get(
+      `https://${ENV0_API_URL}/environments/deployments/${deploymentLogId}`,
+      (req, res, ctx) => {
+        if (credentials) {
+          assertAuth(credentials, req.headers.get("Authorization"));
+        }
+        onSuccess?.();
+        return res(ctx.json(deployment));
+      }
+    )
+  );
+};
+
+export const mockGetDeploymentLogApiResponse = ({
+  deploymentLogId,
+  deploymentLog,
+  stepName,
+  stepStartTime,
+  credentials,
+  onSuccess,
+}: {
+  deploymentLogId: string;
+  deploymentLog: DeploymentStepLogsResponse;
+  stepName: string;
+  stepStartTime?: string;
+  credentials?: Credentials;
+  onSuccess?: () => unknown;
+}) => {
+  server.use(
+    rest.get(
+      `https://${ENV0_API_URL}/deployments/${deploymentLogId}/steps/${stepName}/log?startTime=${
+        stepStartTime ?? ""
+      }`,
+      (req, res, ctx) => {
+        if (credentials) {
+          assertAuth(credentials, req.headers.get("Authorization"));
+        }
+        onSuccess?.();
+        return res(ctx.json(deploymentLog));
+      }
+    )
+  );
+};
+
+export const mockDeploymentLogsResponses = async (
+  deploymentId: string,
+  auth: Credentials,
+  steps: {
+    [stepName: string]: string[];
+  },
+  deploymentStatus: DeploymentStatus = DeploymentStatus.SUCCESS
+) => {
+  mockGetDeploymentApiResponse(deploymentId, auth, {
+    status: deploymentStatus,
+  });
+
+  const stepNames = Object.keys(steps);
+  mockGetDeploymentStepsApiResponse(stepNames.map((name) => ({ name } as any)));
+
+  for (const [stepName, messages] of Object.entries(steps)) {
+    mockGetDeploymentLogApiResponse({
+      deploymentLogId: deploymentId,
+      credentials: auth,
+      stepName,
+      deploymentLog: {
+        events: messages.map((message) => ({ message } as any)),
+        hasMoreLogs: false,
+      },
+    });
+  }
 };
 
 before(() => {

--- a/src/test/integration/suite/authentication.test.it.ts
+++ b/src/test/integration/suite/authentication.test.it.ts
@@ -1,6 +1,6 @@
 import { mockGitRepoAndBranch } from "../mocks/git";
 import {
-  mockGetDeploymentSteps,
+  mockGetDeploymentStepsApiResponse,
   mockGetEnvironment,
   mockGetOrganization,
   mockRedeployApiResponse,
@@ -37,7 +37,7 @@ suite("authentication", function () {
     mockGetOrganization(orgId, auth);
     mockGetEnvironment(orgId, [environmentMock], auth);
     mockGitRepoAndBranch("main", "git@github.com:user/repo.git");
-    mockGetDeploymentSteps();
+    mockGetDeploymentStepsApiResponse();
 
     await login(auth);
     await waitFor(() => expect(getFirstEnvStatus()).toContain("ACTIVE"));

--- a/src/test/integration/suite/deployment-logs.test.it.ts
+++ b/src/test/integration/suite/deployment-logs.test.it.ts
@@ -1,0 +1,153 @@
+import { EnvironmentModel } from "../../../get-environments";
+import { mockGitRepoAndBranch } from "../mocks/git";
+import {
+  getOutputChannelLogs,
+  mockOutputChannel,
+  outputChannelMock,
+  resetOutputChannelMocks,
+} from "../mocks/output-channel";
+import {
+  mockDeploymentLogsResponses,
+  mockGetEnvironment,
+  mockGetOrganization,
+} from "../mocks/server";
+import {
+  clickOnEnvironmentByName,
+  clickOnFirstEnvironment,
+  getEnvironmentMock,
+  getFirstEnvStatus,
+  login,
+  logout,
+  redeploy,
+  resetExtension,
+  waitFor,
+} from "./test-utils";
+import { afterEach, beforeEach } from "mocha";
+import expect from "expect";
+import { DeploymentStatus } from "../../../types";
+
+const auth = { keyId: "key-id", secret: "key-secret" };
+const orgId = "org-id";
+const firstEnvName = "my env";
+const secondEnvName = "my env 2";
+
+let firstEnvironmentMock: EnvironmentModel;
+let secondEnvironmentMock: EnvironmentModel;
+// todo add on selection env to context subscription
+
+suite("deployment logs", function () {
+  this.timeout(1000 * 15);
+
+  beforeEach(async () => {
+    firstEnvironmentMock = getEnvironmentMock(
+      "main",
+      "https://github.com/user/repo",
+      {
+        name: firstEnvName,
+      }
+    );
+    secondEnvironmentMock = getEnvironmentMock(
+      "main",
+      "https://github.com/user/repo",
+      {
+        name: secondEnvName,
+        id: "second-env-id",
+        latestDeploymentLog: {
+          ...firstEnvironmentMock.latestDeploymentLog,
+          id: "second-deployment-id",
+        },
+      }
+    );
+    mockOutputChannel();
+    await resetExtension(); // we need to resat because we are mocking the output channel
+    const environments = [firstEnvironmentMock, secondEnvironmentMock];
+    mockGetOrganization(orgId, auth);
+    mockGetEnvironment(orgId, environments, auth);
+    mockGitRepoAndBranch("main", "git@github.com:user/repo.git");
+    await login(auth);
+    await waitFor(() => expect(getFirstEnvStatus()).toBe("ACTIVE"));
+  });
+
+  afterEach(async () => {
+    await logout();
+    await resetExtension();
+    resetOutputChannelMocks();
+  });
+
+  test("should show deployment logs when click on environment", async () => {
+    const steps = {
+      "git:clone": ["Cloning into 'repo'..."],
+      "state:get": ["Retrieving persisted state for environment..."],
+    };
+    mockDeploymentLogsResponses(
+      firstEnvironmentMock.latestDeploymentLog.id,
+      auth,
+      steps
+    );
+    await clickOnFirstEnvironment();
+
+    await waitFor(() => expect(outputChannelMock.show).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(getOutputChannelLogs()).toEqual(
+        expect.arrayContaining([
+          "Loading logs...",
+          "$$$ git:clone",
+          "Cloning into 'repo'...",
+          "$$$ state:get",
+          "Retrieving persisted state for environment...",
+        ])
+      )
+    );
+  });
+
+  test("should clear log channel when switch between selected environments", async () => {
+    const steps = {
+      "git:clone": ["Cloning into 'repo'..."],
+      "state:get": ["Retrieving persisted state for environment..."],
+    };
+    mockDeploymentLogsResponses(
+      firstEnvironmentMock.latestDeploymentLog.id,
+      auth,
+      steps
+    );
+    await clickOnEnvironmentByName(firstEnvName);
+    await waitFor(() => expect(outputChannelMock.show).toHaveBeenCalled());
+    resetOutputChannelMocks();
+    await clickOnEnvironmentByName(secondEnvName);
+    await waitFor(() => expect(outputChannelMock.show).toHaveBeenCalled());
+    await waitFor(() => expect(outputChannelMock.clear).toHaveBeenCalled());
+  });
+
+  test("should show deployment logs when redeploy", async () => {
+    const steps = {
+      "git:clone": ["Cloning into 'repo'..."],
+      "state:get": ["Retrieving persisted state for environment..."],
+    };
+    const newDeploymentId = "new-deployment-id";
+    mockDeploymentLogsResponses(
+      newDeploymentId,
+      auth,
+      steps,
+      DeploymentStatus.IN_PROGRESS
+    );
+    // todo make sure redeploy request return the new deployment id
+    await redeploy({
+      environment: firstEnvironmentMock,
+      auth,
+      orgId,
+      newDeploymentId,
+    });
+    await waitFor(() => expect(outputChannelMock.show).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(getOutputChannelLogs()).toEqual(
+        expect.arrayContaining([
+          "Loading logs...",
+          "$$$ git:clone",
+          "Cloning into 'repo'...",
+          "$$$ state:get",
+          "Retrieving persisted state for environment...",
+        ])
+      )
+    );
+  });
+});

--- a/src/test/integration/suite/deployment-logs.test.it.ts
+++ b/src/test/integration/suite/deployment-logs.test.it.ts
@@ -35,7 +35,7 @@ let firstEnvironmentMock: EnvironmentModel;
 let secondEnvironmentMock: EnvironmentModel;
 
 suite("deployment logs", function () {
-  this.timeout(1000 * 15);
+  this.timeout(1000 * 10);
 
   beforeEach(async () => {
     firstEnvironmentMock = getEnvironmentMock(

--- a/src/test/integration/suite/deployment-logs.test.it.ts
+++ b/src/test/integration/suite/deployment-logs.test.it.ts
@@ -130,7 +130,6 @@ suite("deployment logs", function () {
       steps,
       DeploymentStatus.IN_PROGRESS
     );
-    // todo make sure redeploy request return the new deployment id
     await redeploy({
       environment: firstEnvironmentMock,
       auth,

--- a/src/test/integration/suite/deployment-logs.test.it.ts
+++ b/src/test/integration/suite/deployment-logs.test.it.ts
@@ -122,7 +122,7 @@ suite("deployment logs", function () {
       "git:clone": ["Cloning into 'repo'..."],
       "state:get": ["Retrieving persisted state for environment..."],
     };
-    const newDeploymentId = "new-deployment-id";
+    const newDeploymentId = "my-new-deployment-id";
     mockDeploymentLogsResponses(
       newDeploymentId,
       auth,

--- a/src/test/integration/suite/deployment-logs.test.it.ts
+++ b/src/test/integration/suite/deployment-logs.test.it.ts
@@ -33,7 +33,6 @@ const secondEnvName = "my env 2";
 
 let firstEnvironmentMock: EnvironmentModel;
 let secondEnvironmentMock: EnvironmentModel;
-// todo add on selection env to context subscription
 
 suite("deployment logs", function () {
   this.timeout(1000 * 15);

--- a/src/test/integration/suite/environment-actions.test.it.ts
+++ b/src/test/integration/suite/environment-actions.test.it.ts
@@ -12,7 +12,7 @@ import {
 import {
   mockApproveApiResponse,
   mockCancelApiResponse,
-  mockGetDeploymentSteps,
+  mockGetDeploymentStepsApiResponse,
   mockGetEnvironment,
   mockGetOrganization,
   mockRedeployApiResponse,
@@ -45,7 +45,7 @@ const initTest = async (environments: EnvironmentModel[]) => {
   mockGetOrganization(orgId, auth);
   mockGetEnvironment(orgId, environments, auth);
   mockGitRepoAndBranch("main", "git@github.com:user/repo.git");
-  mockGetDeploymentSteps();
+  mockGetDeploymentStepsApiResponse();
   spyOnShowMessage();
   spyOnOpenExternal();
   await login(auth);

--- a/src/test/integration/suite/test-utils.ts
+++ b/src/test/integration/suite/test-utils.ts
@@ -68,7 +68,13 @@ export const redeploy = async ({
   onRedeployApiRequest?: typeof jestMock.fn;
   newDeploymentId?: string;
 }) => {
-  mockRedeployApiResponse(environment.id, auth, onRedeployApiRequest);
+  const deploymentId = newDeploymentId || "new-deployment-id";
+  mockRedeployApiResponse(
+    environment.id,
+    auth,
+    onRedeployApiRequest,
+    newDeploymentId
+  );
   vscode.commands.executeCommand("env0.redeploy", getFirstEnvironment());
   const inProgressEnvironment: EnvironmentModel = {
     ...environment,
@@ -76,7 +82,7 @@ export const redeploy = async ({
     updatedAt: Date.now().toString(),
     latestDeploymentLog: {
       ...environment.latestDeploymentLog,
-      id: newDeploymentId || "new-deployment-id",
+      id: deploymentId,
     },
   };
   mockGetEnvironment(orgId, [inProgressEnvironment], auth);

--- a/src/test/integration/suite/test-utils.ts
+++ b/src/test/integration/suite/test-utils.ts
@@ -60,11 +60,13 @@ export const redeploy = async ({
   auth,
   onRedeployApiRequest,
   orgId,
+  newDeploymentId,
 }: {
   environment: EnvironmentModel;
   auth: Credentials;
   orgId: string;
   onRedeployApiRequest?: typeof jestMock.fn;
+  newDeploymentId?: string;
 }) => {
   mockRedeployApiResponse(environment.id, auth, onRedeployApiRequest);
   vscode.commands.executeCommand("env0.redeploy", getFirstEnvironment());
@@ -74,7 +76,7 @@ export const redeploy = async ({
     updatedAt: Date.now().toString(),
     latestDeploymentLog: {
       ...environment.latestDeploymentLog,
-      id: "new-deployment-id",
+      id: newDeploymentId || "new-deployment-id",
     },
   };
   mockGetEnvironment(orgId, [inProgressEnvironment], auth);
@@ -90,10 +92,30 @@ export const getFirstEnvironment = () => {
   const environmentsDataProvider = getEnvironmentDataProvider();
   return environmentsDataProvider.getChildren()[0];
 };
+export const getEnvironmentByName = (name: string) => {
+  const environmentsDataProvider = getEnvironmentDataProvider();
+  return environmentsDataProvider
+    .getChildren()
+    .find((env) => env.name === name);
+};
 
 export const getFirstEnvIconPath = () => getFirstEnvironment().iconPath;
 export const getFirstEnvStatus = () => getFirstEnvironment().status;
 
 export const resetExtension = async () => {
   await extension._reset();
+};
+
+export const clickOnFirstEnvironment = async () => {
+  await extension.environmentsTree.reveal(getFirstEnvironment(), {
+    select: true,
+    focus: true,
+  });
+};
+
+export const clickOnEnvironmentByName = async (name: string) => {
+  await extension.environmentsTree.reveal(getEnvironmentByName(name), {
+    select: true,
+    focus: true,
+  });
 };


### PR DESCRIPTION
Integration tests for logging the latest deployment actions. 
When a user clicks on "redeploy" or selects an environment in the environments view, the latest deployment logs are captured into the VSCode log channel.

Details:
- The tests cover the pulling of logs and their output to the log channel.
- The following scenarios are not covered in this PR:
    - Situations where the step log endpoint returns hasMoreLogs: true.
    - Actions other than "redeploy".
    - Queued deployments.

Please let me know if you'd like additional tests to cover any of the above scenarios or if there are other cases you think should be addressed.