### PR TITLE
Feat deployment logs tests 2

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -95,6 +95,7 @@ export const registerEnvironmentActions = (
             async () => {
               let actionResponse;
               try {
+                env.setIgnoreLogRestartOnSelect(true);
                 await environmentsTree.reveal(env, {
                   select: true,
                   focus: true,
@@ -103,6 +104,7 @@ export const registerEnvironmentActions = (
               } finally {
                 environmentsDataProvider.refresh();
                 restartLogs(env, actionResponse?.id);
+                env.setIgnoreLogRestartOnSelect(false);
               }
             }
           );

--- a/src/env0-environments-provider.ts
+++ b/src/env0-environments-provider.ts
@@ -36,6 +36,16 @@ export class Environment extends vscode.TreeItem {
       this.contextValue = "WAITING_FOR_USER";
     }
   }
+
+  setIgnoreLogRestartOnSelect(value: boolean) {
+    Environment.ignoreRestartLogsOnSelect[this.id] = value;
+  }
+
+  shouldIgnoreRestartLogsOnSelect() {
+    return Environment.ignoreRestartLogsOnSelect[this.id];
+  }
+
+  static ignoreRestartLogsOnSelect: Record<string, boolean> = {};
 }
 
 export class Env0EnvironmentsProvider

--- a/src/env0-environments-provider.ts
+++ b/src/env0-environments-provider.ts
@@ -38,7 +38,11 @@ export class Environment extends vscode.TreeItem {
   }
 
   setIgnoreLogRestartOnSelect(value: boolean) {
-    Environment.ignoreRestartLogsOnSelect[this.id] = value;
+    if (value) {
+      Environment.ignoreRestartLogsOnSelect[this.id] = value;
+    } else {
+      delete Environment.ignoreRestartLogsOnSelect[this.id];
+    }
   }
 
   shouldIgnoreRestartLogsOnSelect() {

--- a/src/environment-logs-provider.ts
+++ b/src/environment-logs-provider.ts
@@ -107,12 +107,13 @@ export class EnvironmentLogsProvider {
         startTime,
         this.abortController
       );
+    let result = [...events];
     if (hasMoreLogs && nextStartTime) {
-      events.concat(
+      result = result.concat(
         await this.getStepLogs(deploymentId, stepName, nextStartTime)
       );
     }
-    return events;
+    return result;
   }
 
   private async logInProgressDeployment(deploymentId: string) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -93,9 +93,9 @@ export async function activate(context: vscode.ExtensionContext) {
 
   context.subscriptions.push(
     environmentsTree.onDidChangeSelection(async (e) => {
-      const env = e.selection[0];
+      const env = e.selection[0] as Environment;
 
-      if (env) {
+      if (env && !env.shouldIgnoreRestartLogsOnSelect()) {
         restartLogs(env);
       }
     })

--- a/src/test/integration/suite/deployment-logs.test.it.ts
+++ b/src/test/integration/suite/deployment-logs.test.it.ts
@@ -75,7 +75,7 @@ suite("deployment logs", function () {
 
   test("should show deployment logs when click on environment", async () => {
     const steps = {
-      "git:clone": ["Cloning into 'repo'..."],
+      "git:clone": ["Cloning into 'repo'...", "Clone done"],
       "state:get": ["Retrieving persisted state for environment..."],
     };
     mockDeploymentLogsResponses(
@@ -92,6 +92,7 @@ suite("deployment logs", function () {
           "Loading logs...",
           "$$$ git:clone",
           "Cloning into 'repo'...",
+          "Clone done",
           "$$$ state:get",
           "Retrieving persisted state for environment...",
         ])
@@ -101,7 +102,7 @@ suite("deployment logs", function () {
 
   test("should clear log channel when switch between selected environments", async () => {
     const steps = {
-      "git:clone": ["Cloning into 'repo'..."],
+      "git:clone": ["Cloning into 'repo'...", "Clone done"],
       "state:get": ["Retrieving persisted state for environment..."],
     };
     mockDeploymentLogsResponses(
@@ -119,7 +120,7 @@ suite("deployment logs", function () {
 
   test("should show deployment logs when redeploy", async () => {
     const steps = {
-      "git:clone": ["Cloning into 'repo'..."],
+      "git:clone": ["Cloning into 'repo'...", "Clone done"],
       "state:get": ["Retrieving persisted state for environment..."],
     };
     const newDeploymentId = "my-new-deployment-id";
@@ -142,6 +143,7 @@ suite("deployment logs", function () {
           "Loading logs...",
           "$$$ git:clone",
           "Cloning into 'repo'...",
+          "Clone done",
           "$$$ state:get",
           "Retrieving persisted state for environment...",
         ])

--- a/src/test/integration/suite/deployment-logs.test.it.ts
+++ b/src/test/integration/suite/deployment-logs.test.it.ts
@@ -8,6 +8,7 @@ import {
 } from "../mocks/output-channel";
 import {
   mockDeploymentLogsResponses,
+  mockGetDeploymentApiResponse,
   mockGetEnvironment,
   mockGetOrganization,
 } from "../mocks/server";
@@ -35,9 +36,10 @@ let firstEnvironmentMock: EnvironmentModel;
 let secondEnvironmentMock: EnvironmentModel;
 
 suite("deployment logs", function () {
-  this.timeout(1000 * 10);
+  this.timeout(1000 * 13);
 
   beforeEach(async () => {
+    mockGitRepoAndBranch("main", "git@github.com:user/repo.git");
     firstEnvironmentMock = getEnvironmentMock(
       "main",
       "https://github.com/user/repo",
@@ -62,7 +64,6 @@ suite("deployment logs", function () {
     const environments = [firstEnvironmentMock, secondEnvironmentMock];
     mockGetOrganization(orgId, auth);
     mockGetEnvironment(orgId, environments, auth);
-    mockGitRepoAndBranch("main", "git@github.com:user/repo.git");
     await login(auth);
     await waitFor(() => expect(getFirstEnvStatus()).toBe("ACTIVE"));
   });
@@ -148,6 +149,53 @@ suite("deployment logs", function () {
           "Retrieving persisted state for environment...",
         ])
       )
+    );
+  });
+
+  test("should log deployment queued when deployment queued", async () => {
+    const steps = {
+      "git:clone": ["Cloning into 'repo'...", "Clone done"],
+      "state:get": ["Retrieving persisted state for environment..."],
+    };
+    const newDeploymentId = "my-new-deployment-id";
+    mockGetDeploymentApiResponse(newDeploymentId, auth, {
+      status: DeploymentStatus.QUEUED,
+    });
+    await redeploy({
+      environment: firstEnvironmentMock,
+      auth,
+      orgId,
+      newDeploymentId,
+    });
+    await waitFor(() => expect(outputChannelMock.show).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(getOutputChannelLogs()).toEqual(
+        expect.arrayContaining([
+          "Deployment is queued! Waiting for it to start...",
+        ])
+      )
+    );
+
+    mockDeploymentLogsResponses(
+      newDeploymentId,
+      auth,
+      steps,
+      DeploymentStatus.IN_PROGRESS
+    );
+
+    await waitFor(
+      () =>
+        expect(getOutputChannelLogs()).toEqual(
+          expect.arrayContaining([
+            "Loading logs...",
+            "$$$ git:clone",
+            "Cloning into 'repo'...",
+            "Clone done",
+            "$$$ state:get",
+            "Retrieving persisted state for environment...",
+          ])
+        ),
+      10
     );
   });
 });


### PR DESCRIPTION
- Added tests to check logs for queued deployment.
- Adjusted the current test to handle cases where the logs API shows hasMoreLogs: true, making sure it keeps polling for subsequent logs.
- Stopped double calls to restart logs during environment action.
- Fixed an issue where logs were not being concatenated correctly.