### PR TITLE
fix: deployment logs slow fetching

### DIFF
--- a/src/environment-logs-provider.ts
+++ b/src/environment-logs-provider.ts
@@ -179,6 +179,10 @@ export class EnvironmentLogsProvider {
         return this.logCompletedDeployment(deploymentId);
       }
       const stepsToLog = await this.getStepsToLog(deploymentId);
+      if (stepsToLog.length === 0) {
+        await sleep(pollStepLogsInterval);
+        continue;
+      }
       for (const step of stepsToLog) {
         await this.writeDeploymentStepLog(deploymentId, step.name);
         this.stepsAlreadyLogged.push(step.name);


### PR DESCRIPTION
Problem:
Currently, there is a delay of 30 seconds up to a minute between receiving the "Active environment" notification and the completion of log retrieval. 
Solution:
Optimized the deployment logs for faster retrieval and printing. 
The new implementation checks the deployment status while polling and printing logs 
Once the deployment is confirmed to be completed, switched to using the `logCompletedDeployment` function, which is significantly faster.
before my change it takes 20 sec to complete the logging 


https://github.com/env0/vscode-env0/assets/33559192/6707ddff-f8a8-42bb-a490-abc1fe1a0393



after my change it takes 5 sec to complete the logging 


https://github.com/env0/vscode-env0/assets/33559192/fee0c130-0a4f-4ebb-ab02-2c37e57b0c4c

