### PR TITLE
feat: move api and web url to vscode configuration 

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,11 +11,7 @@
       "request": "launch",
       "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
       "outFiles": ["${workspaceFolder}/dist/**/*.js"],
-      "preLaunchTask": "${defaultBuildTask}",
-      "env": {
-        "ENV0_API_URL": "api-dev.dev.env0.com",
-        "ENV0_WEB_URL": "dev.dev.env0.com"
-      }
+      "preLaunchTask": "${defaultBuildTask}"
     },
     {
       "name": "Extension Tests",
@@ -30,11 +26,7 @@
         "${workspaceFolder}/dist/**/*.js"
       ],
       "cwd": "${workspaceFolder}",
-      "preLaunchTask": "npm: pretest",
-      "env": {
-        "ENV0_API_URL": "api-dev.dev.env0.com",
-        "ENV0_WEB_URL": "dev.dev.env0.com"
-      }
+      "preLaunchTask": "npm: pretest"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,21 @@
   ],
   "main": "./dist/extension.js",
   "contributes": {
+    "configuration": {
+      "title": "env0",
+      "properties": {
+        "env0.apiUrl": {
+          "type": "string",
+          "required": true,
+          "default": "api.env0.com"
+        },
+        "env0.webUrl": {
+          "type": "string",
+          "required": true,
+          "default": "app.env0.com"
+        }
+      }
+    },
     "commands": [
       {
         "command": "env0.openInEnv0",

--- a/package.json
+++ b/package.json
@@ -24,12 +24,10 @@
       "properties": {
         "env0.apiUrl": {
           "type": "string",
-          "required": true,
           "default": "api.env0.com"
         },
         "env0.webUrl": {
           "type": "string",
-          "required": true,
           "default": "app.env0.com"
         }
       }

--- a/src/common.ts
+++ b/src/common.ts
@@ -1,3 +1,7 @@
-export const ENV0_API_URL = process.env.ENV0_API_URL || "api.env0.com";
-export const ENV0_WEB_URL = process.env.ENV0_WEB_URL || "app.env0.com";
+import * as vscode from "vscode";
+
+export const ENV0_API_URL =
+  vscode.workspace.getConfiguration("env0").get("apiUrl") || "api.env0.com";
+export const ENV0_WEB_URL =
+  vscode.workspace.getConfiguration("env0").get("webUrl") || "app.env0.com";
 export const ENV0_ENVIRONMENTS_VIEW_ID = "env0-environments";

--- a/src/test/unit/mocks/vscode.ts
+++ b/src/test/unit/mocks/vscode.ts
@@ -17,7 +17,13 @@ export const vscode = {
       .fn()
       .mockImplementation((options: any, task: any) => task()),
   },
+  workspace: {
+    getConfiguration: () => ({
+      get: mocker.fn(),
+    }),
+  },
 };
+
 mock("vscode", vscode);
 
 export const mockLoginCredentialsInput = (keyId: string, secret: string) => {


### PR DESCRIPTION
- Removed env0 api and web url from env vars
- Added env0 api and web url to extension configuration
- Added mock for unit tests
- Changed default URL to production URL
