### PR TITLE
Fix hide inactive environments

### DIFF
--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -66,7 +66,7 @@ class ApiClient {
     const response = await this.instance.get<EnvironmentModel[]>(
       `/environments`,
       {
-        params: { organizationId },
+        params: { organizationId, isActive: true },
       }
     );
 

--- a/src/get-environments.ts
+++ b/src/get-environments.ts
@@ -52,18 +52,15 @@ export async function getEnvironmentsForBranch() {
     } else {
       extensionState.setCurrentBranch(currentBranch);
     }
-    environments = environments
-      .filter(
-        (environment) =>
-          repositoriesEqual(
-            environment?.latestDeploymentLog?.blueprintRepository,
-            repository
-          ) &&
-          environment?.latestDeploymentLog?.blueprintRevision === currentBranch
-      )
-      .filter((environment) => environment.status !== "INACTIVE");
+    environments = environments.filter(
+      (environment) =>
+        repositoriesEqual(
+          environment?.latestDeploymentLog?.blueprintRepository,
+          repository
+        ) &&
+        environment?.latestDeploymentLog?.blueprintRevision === currentBranch
+    );
   }
-
   return environments;
 }
 

--- a/src/test/integration/suite/environments.test.it.ts
+++ b/src/test/integration/suite/environments.test.it.ts
@@ -49,30 +49,6 @@ suite("environments", function () {
     });
   });
 
-  test("should not show inactive environments", async () => {
-    const activeEnvName = "active env";
-    const inactiveEnvName = "inactive env";
-    const environments = [
-      getEnvironmentMock("main", "https://github.com/user/repo", {
-        name: activeEnvName,
-      }),
-      getEnvironmentMock("main", "https://github.com/user/repo", {
-        status: "INACTIVE",
-        name: inactiveEnvName,
-      }),
-    ];
-    await initTest(environments);
-
-    const environmentsDataProvider =
-      extension.environmentsDataProvider as Env0EnvironmentsProvider;
-
-    await waitFor(() => {
-      const environments = environmentsDataProvider.getChildren();
-      expect(environments).toHaveLength(1);
-      expect(environments[0].label).toBe(activeEnvName);
-    });
-  });
-
   test("should show environments only for the current repo", async () => {
     const envName = "active env";
     const differentRepoEnvName = "different repo env";


### PR DESCRIPTION
Problem:
In the current implementation, all environments are retrieved from the server, and then the inactive environments are filtered out based on their status. However, there have been situations where environments that failed to be destroyed were still visible to the user, even though they were inactive.

Solution:
Simply passed the isActive: true parameter to the "get environments" request, as we do in the frontend.