### PR TITLE
Fix: Allow Project Deployer Users to Read environments

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,11 +28,11 @@
       "properties": {
         "env0.apiUrl": {
           "type": "string",
-          "default": "api-dev.dev.env0.com"
+          "default": "api.env0.com"
         },
         "env0.webUrl": {
           "type": "string",
-          "default": "dev.dev.env0.com"
+          "default": "app.env0.com"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -28,11 +28,11 @@
       "properties": {
         "env0.apiUrl": {
           "type": "string",
-          "default": "api.env0.com"
+          "default": "api-dev.dev.env0.com"
         },
         "env0.webUrl": {
           "type": "string",
-          "default": "app.env0.com"
+          "default": "dev.dev.env0.com"
         }
       }
     },

--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosInstance } from "axios";
 import { ENV0_API_URL } from "./common";
-import { EnvironmentModel } from "./get-environments";
+import { EnvironmentModel, Project } from "./get-environments";
 import { DeploymentStepLogsResponse, DeploymentStepResponse } from "./types";
 import { AuthService } from "./auth";
 
@@ -63,17 +63,28 @@ class ApiClient {
     return response.data;
   }
 
-  public async getEnvironments() {
+  public async getUserProjects(): Promise<Project[]> {
+    const response = await this.instance.get<EnvironmentModel[]>("/projects", {
+      params: {
+        organizationId: this.authService?.getCredentials().selectedOrgId,
+        isArchived: false,
+      },
+    });
+
+    return response.data;
+  }
+
+  // TODO: support paginzation
+  public async getEnvironments(projectId: string): Promise<EnvironmentModel[]> {
     const response = await this.instance.get<EnvironmentModel[]>(
       `/environments`,
       {
         params: {
-          organizationId: this.authService?.getCredentials().selectedOrgId,
+          projectId,
           isActive: true,
         },
       }
     );
-
     return response.data;
   }
 

--- a/src/common.ts
+++ b/src/common.ts
@@ -1,7 +1,8 @@
 import * as vscode from "vscode";
 
 export const ENV0_API_URL =
-  vscode.workspace.getConfiguration("env0").get("apiUrl") || "api.env0.com";
+  vscode.workspace.getConfiguration("env0").get("apiUrl") ||
+  "api-dev.dev.env0.com";
 export const ENV0_WEB_URL =
-  vscode.workspace.getConfiguration("env0").get("webUrl") || "app.env0.com";
+  vscode.workspace.getConfiguration("env0").get("webUrl") || "dev.dev.env0.com";
 export const ENV0_ENVIRONMENTS_VIEW_ID = "env0-environments";

--- a/src/get-environments.ts
+++ b/src/get-environments.ts
@@ -16,13 +16,15 @@ export type EnvironmentModel = {
       message?: string;
     };
   };
-}; // TODO: change to real Environment Model
+};
+
+export type Project = any; // TODO: change to real Project Model
 
 // Extracts the prefix from http or ssh repositories.
 const repositoryPrefixRegex = /.*[:/]([^/]+\/[^/]+)/;
 
 // Compares repositories irrespective if they're https or ssh.
-function repositoriesEqual(rep1: string, rep2: string): boolean {
+export function repositoriesEqual(rep1: string, rep2: string): boolean {
   const res1 = repositoryPrefixRegex.exec(rep1);
   const res2 = repositoryPrefixRegex.exec(rep2);
 
@@ -38,7 +40,17 @@ function repositoriesEqual(rep1: string, rep2: string): boolean {
 export async function getEnvironmentsForBranch() {
   let environments: EnvironmentModel[] = [];
 
-  environments = await apiClient.getEnvironments();
+  // get all projects
+  const projects: Project[] = await apiClient.getUserProjects();
+  console.log("projects", projects);
+  environments = (
+    await Promise.all(
+      projects
+        .filter((project) => !project.isArchived)
+        .map(async (project: Project) => apiClient.getEnvironments(project.id))
+    )
+  ).flat();
+  // get all environments of all projects
 
   if (environments.length > 0) {
     const { currentBranch, repository } = getGitRepoAndBranch();


### PR DESCRIPTION
resolves #69 

Basically the suggested solution here is to read environments by user projects instead of reading all environments by organization Id. This is b/c if the user is trying to get all environments by org-id, the following validation is applied ( which prevents project-deployer users to use the extension)

```authorize.hasOrganizationPermissions(organizationId, PERMISSIONS.VIEW_PROJECT, PERMISSIONS.VIEW_ENVIRONMENT)```